### PR TITLE
hotfix/fixLoadError

### DIFF
--- a/js/pages/startPage.js
+++ b/js/pages/startPage.js
@@ -75,8 +75,10 @@ export default class StartPage {
       timer = setTimeout(showSlides, 4000);
     };
 
-    $('main').load('load', showSlides);
-
+    //$('main').load('load', showSlides);
+    $(document).ready(function () {
+      showSlides();
+    });
     return `
       <div class="big-container">
         <div class="startpage-infobar">

--- a/js/router.js
+++ b/js/router.js
@@ -57,6 +57,7 @@ export default class Router {
   // Our pages (the method names matches the hashes with any slashes - removed)
 
   default() {
+    window.location.href = "#startPage";
     return startPage.render();
   }
 


### PR DESCRIPTION
Was a potential bug in slides not showing up when defaulting to accessing with localhost:3000, put in default to have href refer to #startPage to prevent ending up in something that was not the actual startPage rendering

Also fixed the issue with 404 of failing to find resource in terms of Load - the Ajax callback of Load defines a resource to load - and 'load' is not a HTML resource - replaced this with the jQuery of $(document).ready and calling showSlides there after