### PR TITLE
feature/preventBookingInPast

### DIFF
--- a/css/pages/BookingPage.css
+++ b/css/pages/BookingPage.css
@@ -105,3 +105,54 @@
   border-radius: 3px;
   border-color: #e1e0e2;
 }
+
+.BookingPage.BookingModal {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.BookingPage.modal-content {
+  font-family: 'Montserrat', sans-serif;
+  background-color: grey;
+  margin: 15% auto;
+  padding: 20px;
+  border: 2px solid black;
+  text-align: center;
+  min-width: max-content;
+  max-width: 40%;
+  border-radius: 15px;
+}
+
+.BookingPage.closeSuccessfulBookingModal,
+.BookingPage.closeFailedBookingModal {
+  color: black;
+  float: right;
+  font-size: 26px;
+  font-weight: lighter;
+  position: relative;
+  bottom: 5px;
+  background-color: grey;
+  box-shadow: 0px 0px 12px -2px rgba(0, 0, 0, 0.5);
+  text-align: center;
+  display: inline;
+  width: 2rem;
+  height: 2rem;
+  padding-bottom: 1rem;
+  border-radius: 100px;
+  outline: none;
+  border: none;
+}
+
+.BookingPage.closeFailedBookingModal:hover,
+.BookingPage.closeFailedBookingModal:focus {
+  background-color: silver;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/js/pages/BookingPage.js
+++ b/js/pages/BookingPage.js
@@ -3,13 +3,37 @@ export default class BookingPage {
 
   constructor() {
     let that = this;
+    $('body').on('click', '.datePicker', function () {
+      //Assign the previousDate to be able to default to the previous Date
+      that.previousDate = $(this).val();
+    })
     $('body').on('change', '.datePicker', async function () {
-      that.showDate = $(this).val();
-      $('main').html(await that.render());
+      if ($(this).val() >= new Date().toISOString().slice(0, 10)) {
+        //If the showDate chosen is valid, change the showDate and re-render the update
+        that.showDate = $(this).val();
+        $('main').html(await that.render());
+      } else {
+        //If not, just re-assign the value of the date picker to be the previous date
+        $(this).val(that.previousDate);
+        //And then display the Modal
+        $('main').prepend(`
+      <div class="BookingPage BookingModal">
+        <div class="BookingPage modal-content">
+          <span class="BookingPage closeFailedBookingModal">&times;</span>
+          <p>Du kan ej boka ett datum som redan passerat!</p>
+        </div>
+      </div>`);
+      }
     });
     this.eventHandler();
+    this.addCloseModalHandler();
   }
 
+  addCloseModalHandler() {
+    $('main').on('click', '.BookingPage.closeFailedBookingModal', (event) => {
+      $('.BookingModal').remove();
+    });
+  }
   async readShowsFromJson() {
     this.shows = await $.getJSON('json/movieSchedule.json');
     this.movies = await $.getJSON('json/movies.json');


### PR DESCRIPTION
Added so that if a date is attempted to be picked, that is in the past, it will pop up a Modal and not render those movies - keeps track of the previous date when clicking too, as to know what value to default back to when not re-rendering with the faulty past in-time value.

Wanted to implement disabled attributes for previous dates to make it extra clear, but would require additional imports such as jQuery UI and additional efforts in re-constructing the datePicker - which was deemed as too tight on time to integrate at the moment.