### PR TITLE
Hotfixed max-length of login modal

### DIFF
--- a/css/components/login_form.css
+++ b/css/components/login_form.css
@@ -164,7 +164,7 @@ button.loginPage.cancel_button:hover {
   margin: 15% auto;
   padding: 20px;
   min-width: 200px;
-  max-width:calc(100% - 600px);
+  max-width: min(400px, 35vw);
   max-height: max-content;
   border-radius: 15px;
   margin-top:50vh;


### PR DESCRIPTION
Width was too large, hotfixed to resort to minimal of one of two values based on Screen width